### PR TITLE
Move to Alpine 3.6, glibc 2.25-r0 and add support for sdk-alpine images.

### DIFF
--- a/ibmjava/8/jre/x86_64/alpine/Dockerfile
+++ b/ibmjava/8/jre/x86_64/alpine/Dockerfile
@@ -23,12 +23,12 @@ FROM alpine:3.6
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 
-RUN apk --update add --no-cache openssl ca-certificates xz \
+RUN apk --update add --no-cache ca-certificates curl openssl xz \
     && GLIBC_VER="2.25-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && wget -q -O /tmp/$GLIBC_VER.apk $ALPINE_GLIBC_REPO/$GLIBC_VER/glibc-$GLIBC_VER.apk \
+    && curl -Ls $ALPINE_GLIBC_REPO/$GLIBC_VER/glibc-$GLIBC_VER.apk > /tmp/$GLIBC_VER.apk \
     && apk add --allow-untrusted /tmp/$GLIBC_VER.apk \
-    && wget -q -O /tmp/gcc-libs.tar.xz https://www.archlinux.org/packages/core/x86_64/gcc-libs/download \
+    && curl -Ls https://www.archlinux.org/packages/core/x86_64/gcc-libs/download > /tmp/gcc-libs.tar.xz \
     && mkdir /tmp/gcc \
     && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /usr/glibc-compat/lib \

--- a/ibmjava/8/jre/x86_64/alpine/Dockerfile
+++ b/ibmjava/8/jre/x86_64/alpine/Dockerfile
@@ -32,6 +32,7 @@ RUN apk --update add --no-cache ca-certificates curl openssl xz \
     && mkdir /tmp/gcc \
     && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /usr/glibc-compat/lib \
+    && apk del curl \
     && rm -rf /tmp/$GLIBC_VER.apk /tmp/gcc /tmp/gcc-libs.tar.xz /var/cache/apk/*
 
 ENV JAVA_VERSION 1.8.0_sr4fp6

--- a/ibmjava/8/jre/x86_64/alpine/Dockerfile
+++ b/ibmjava/8/jre/x86_64/alpine/Dockerfile
@@ -19,16 +19,15 @@
 # limitations under the License.
 #
 
-FROM alpine:3.4
+FROM alpine:3.6
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 
-RUN apk --update add --no-cache openssl ca-certificates \
-    && GLIBC_VER="2.23-r3" \
+RUN apk --update add --no-cache openssl ca-certificates xz \
+    && GLIBC_VER="2.25-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
     && wget -q -O /tmp/$GLIBC_VER.apk $ALPINE_GLIBC_REPO/$GLIBC_VER/glibc-$GLIBC_VER.apk \
     && apk add --allow-untrusted /tmp/$GLIBC_VER.apk \
-    && apk --update add xz \
     && wget -q -O /tmp/gcc-libs.tar.xz https://www.archlinux.org/packages/core/x86_64/gcc-libs/download \
     && mkdir /tmp/gcc \
     && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \

--- a/ibmjava/8/sdk/README.md
+++ b/ibmjava/8/sdk/README.md
@@ -4,7 +4,10 @@ Dockerfiles and build scripts for generating various Docker Images related to IB
 The following architectures are supported for each of the packages with the default operating system as Ubuntu:
 
 * [i386](i386)
-* [x86\_64](x86_64)
+* [x86\_64](x86_64) supports two operating systems
+  * [alpine](x86_64/alpine)
+  * [ubuntu](x86_64/ubuntu)
 * [ppc64le](ppc64le)
 * [s390](s390)
 * [s390x](s390x)
+

--- a/ibmjava/8/sdk/x86_64/alpine/Dockerfile
+++ b/ibmjava/8/sdk/x86_64/alpine/Dockerfile
@@ -23,12 +23,12 @@ FROM alpine:3.6
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 
-RUN apk --update add --no-cache openssl ca-certificates xz \
+RUN apk --update add --no-cache ca-certificates curl openssl xz \
     && GLIBC_VER="2.25-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && wget -q -O /tmp/$GLIBC_VER.apk $ALPINE_GLIBC_REPO/$GLIBC_VER/glibc-$GLIBC_VER.apk \
+    && curl -Ls $ALPINE_GLIBC_REPO/$GLIBC_VER/glibc-$GLIBC_VER.apk > /tmp/$GLIBC_VER.apk \
     && apk add --allow-untrusted /tmp/$GLIBC_VER.apk \
-    && wget -q -O /tmp/gcc-libs.tar.xz https://www.archlinux.org/packages/core/x86_64/gcc-libs/download \
+    && curl -Ls https://www.archlinux.org/packages/core/x86_64/gcc-libs/download > /tmp/gcc-libs.tar.xz \
     && mkdir /tmp/gcc \
     && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /usr/glibc-compat/lib \

--- a/ibmjava/8/sdk/x86_64/alpine/Dockerfile
+++ b/ibmjava/8/sdk/x86_64/alpine/Dockerfile
@@ -32,6 +32,7 @@ RUN apk --update add --no-cache ca-certificates curl openssl xz \
     && mkdir /tmp/gcc \
     && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /usr/glibc-compat/lib \
+    && apk del curl \
     && rm -rf /tmp/$GLIBC_VER.apk /tmp/gcc /tmp/gcc-libs.tar.xz /var/cache/apk/*
 
 ENV JAVA_VERSION 1.8.0_sr4fp6

--- a/ibmjava/8/sdk/x86_64/alpine/Dockerfile
+++ b/ibmjava/8/sdk/x86_64/alpine/Dockerfile
@@ -31,12 +31,12 @@ RUN apk --update add --no-cache openssl ca-certificates xz \
     && wget -q -O /tmp/gcc-libs.tar.xz https://www.archlinux.org/packages/core/x86_64/gcc-libs/download \
     && mkdir /tmp/gcc \
     && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
-    && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
+    && mv /tmp/gcc/usr/lib/libgcc* /usr/glibc-compat/lib \
     && rm -rf /tmp/$GLIBC_VER.apk /tmp/gcc /tmp/gcc-libs.tar.xz /var/cache/apk/*
 
-ENV JAVA_VERSION 1.9.0_ea2
+ENV JAVA_VERSION 1.8.0_sr4fp6
 
-RUN ESUM="0fe3712b54a93695cf4948d9ae171bf5cef038c0e41b364b4e9eb7cb80a60688" \
+RUN ESUM="d5b1f62eb8db7ce1ccf80165cd27c3c4e21d3ccf5c86dbd6b1df81b2b7947371" \
     && BASE_URL="https://public.dhe.ibm.com/ibmdl/export/pub/systems/cloud/runtimes/java/meta/" \
     && YML_FILE="sdk/linux/x86_64/index.yml" \
     && wget -q -U UA_IBM_JAVA_Docker -O /tmp/index.yml $BASE_URL/$YML_FILE \
@@ -51,11 +51,7 @@ RUN ESUM="0fe3712b54a93695cf4948d9ae171bf5cef038c0e41b364b4e9eb7cb80a60688" \
     && /tmp/ibm-java.bin -i silent -f /tmp/response.properties \
     && rm -f /tmp/response.properties \
     && rm -f /tmp/index.yml \
-    && rm -f /tmp/ibm-java.bin \
-    && cd /opt/ibm \
-    && ./java/bin/jlink -G --module-path ./java/jmods --add-modules java.se.ee --output jre \
-    && rm -rf java/* \
-    && mv jre java
+    && rm -f /tmp/ibm-java.bin
 
 ENV JAVA_HOME=/opt/ibm/java/jre \
-    PATH=/opt/ibm/java/jre/bin:$PATH
+    PATH=/opt/ibm/java/bin:$PATH

--- a/ibmjava/8/sfj/x86_64/alpine/Dockerfile
+++ b/ibmjava/8/sfj/x86_64/alpine/Dockerfile
@@ -23,12 +23,12 @@ FROM alpine:3.6
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 
-RUN apk --update add --no-cache openssl ca-certificates xz \
+RUN apk --update add --no-cache ca-certificates curl openssl xz \
     && GLIBC_VER="2.25-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && wget -q -O /tmp/$GLIBC_VER.apk $ALPINE_GLIBC_REPO/$GLIBC_VER/glibc-$GLIBC_VER.apk \
+    && curl -Ls $ALPINE_GLIBC_REPO/$GLIBC_VER/glibc-$GLIBC_VER.apk > /tmp/$GLIBC_VER.apk \
     && apk add --allow-untrusted /tmp/$GLIBC_VER.apk \
-    && wget -q -O /tmp/gcc-libs.tar.xz https://www.archlinux.org/packages/core/x86_64/gcc-libs/download \
+    && curl -Ls https://www.archlinux.org/packages/core/x86_64/gcc-libs/download > /tmp/gcc-libs.tar.xz \
     && mkdir /tmp/gcc \
     && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /usr/glibc-compat/lib \

--- a/ibmjava/8/sfj/x86_64/alpine/Dockerfile
+++ b/ibmjava/8/sfj/x86_64/alpine/Dockerfile
@@ -32,6 +32,7 @@ RUN apk --update add --no-cache ca-certificates curl openssl xz \
     && mkdir /tmp/gcc \
     && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /usr/glibc-compat/lib \
+    && apk del curl \
     && rm -rf /tmp/$GLIBC_VER.apk /tmp/gcc /tmp/gcc-libs.tar.xz /var/cache/apk/*
 
 ENV JAVA_VERSION 1.8.0_sr4fp6

--- a/ibmjava/8/sfj/x86_64/alpine/Dockerfile
+++ b/ibmjava/8/sfj/x86_64/alpine/Dockerfile
@@ -19,16 +19,15 @@
 # limitations under the License.
 #
 
-FROM alpine:3.4
+FROM alpine:3.6
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 
-RUN apk --update add --no-cache openssl ca-certificates \
-    && GLIBC_VER="2.23-r3" \
+RUN apk --update add --no-cache openssl ca-certificates xz \
+    && GLIBC_VER="2.25-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
     && wget -q -O /tmp/$GLIBC_VER.apk $ALPINE_GLIBC_REPO/$GLIBC_VER/glibc-$GLIBC_VER.apk \
     && apk add --allow-untrusted /tmp/$GLIBC_VER.apk \
-    && apk --update add xz \
     && wget -q -O /tmp/gcc-libs.tar.xz https://www.archlinux.org/packages/core/x86_64/gcc-libs/download \
     && mkdir /tmp/gcc \
     && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \

--- a/ibmjava/9/jre/x86_64/alpine/Dockerfile
+++ b/ibmjava/9/jre/x86_64/alpine/Dockerfile
@@ -23,12 +23,12 @@ FROM alpine:3.6
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 
-RUN apk --update add --no-cache openssl ca-certificates xz \
+RUN apk --update add --no-cache ca-certificates curl openssl xz \
     && GLIBC_VER="2.25-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && wget -q -O /tmp/$GLIBC_VER.apk $ALPINE_GLIBC_REPO/$GLIBC_VER/glibc-$GLIBC_VER.apk \
+    && curl -Ls $ALPINE_GLIBC_REPO/$GLIBC_VER/glibc-$GLIBC_VER.apk > /tmp/$GLIBC_VER.apk \
     && apk add --allow-untrusted /tmp/$GLIBC_VER.apk \
-    && wget -q -O /tmp/gcc-libs.tar.xz https://www.archlinux.org/packages/core/x86_64/gcc-libs/download \
+    && curl -Ls https://www.archlinux.org/packages/core/x86_64/gcc-libs/download > /tmp/gcc-libs.tar.xz \
     && mkdir /tmp/gcc \
     && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \

--- a/ibmjava/9/jre/x86_64/alpine/Dockerfile
+++ b/ibmjava/9/jre/x86_64/alpine/Dockerfile
@@ -32,6 +32,7 @@ RUN apk --update add --no-cache ca-certificates curl openssl xz \
     && mkdir /tmp/gcc \
     && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
+    && apk del curl \
     && rm -rf /tmp/$GLIBC_VER.apk /tmp/gcc /tmp/gcc-libs.tar.xz /var/cache/apk/*
 
 ENV JAVA_VERSION 1.9.0_ea2

--- a/ibmjava/9/sdk/x86_64/alpine/Dockerfile
+++ b/ibmjava/9/sdk/x86_64/alpine/Dockerfile
@@ -51,11 +51,7 @@ RUN ESUM="0fe3712b54a93695cf4948d9ae171bf5cef038c0e41b364b4e9eb7cb80a60688" \
     && /tmp/ibm-java.bin -i silent -f /tmp/response.properties \
     && rm -f /tmp/response.properties \
     && rm -f /tmp/index.yml \
-    && rm -f /tmp/ibm-java.bin \
-    && cd /opt/ibm \
-    && ./java/bin/jlink -G --module-path ./java/jmods --add-modules java.se.ee --output jre \
-    && rm -rf java/* \
-    && mv jre java
+    && rm -f /tmp/ibm-java.bin
 
-ENV JAVA_HOME=/opt/ibm/java/jre \
-    PATH=/opt/ibm/java/jre/bin:$PATH
+ENV JAVA_HOME=/opt/ibm/java \
+    PATH=/opt/ibm/java/bin:$PATH

--- a/ibmjava/9/sdk/x86_64/alpine/Dockerfile
+++ b/ibmjava/9/sdk/x86_64/alpine/Dockerfile
@@ -23,12 +23,12 @@ FROM alpine:3.6
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 
-RUN apk --update add --no-cache openssl ca-certificates xz \
+RUN apk --update add --no-cache ca-certificates curl openssl xz \
     && GLIBC_VER="2.25-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && wget -q -O /tmp/$GLIBC_VER.apk $ALPINE_GLIBC_REPO/$GLIBC_VER/glibc-$GLIBC_VER.apk \
+    && curl -Ls $ALPINE_GLIBC_REPO/$GLIBC_VER/glibc-$GLIBC_VER.apk > /tmp/$GLIBC_VER.apk \
     && apk add --allow-untrusted /tmp/$GLIBC_VER.apk \
-    && wget -q -O /tmp/gcc-libs.tar.xz https://www.archlinux.org/packages/core/x86_64/gcc-libs/download \
+    && curl -Ls https://www.archlinux.org/packages/core/x86_64/gcc-libs/download > /tmp/gcc-libs.tar.xz \
     && mkdir /tmp/gcc \
     && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \

--- a/ibmjava/9/sdk/x86_64/alpine/Dockerfile
+++ b/ibmjava/9/sdk/x86_64/alpine/Dockerfile
@@ -32,6 +32,7 @@ RUN apk --update add --no-cache ca-certificates curl openssl xz \
     && mkdir /tmp/gcc \
     && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
+    && apk del curl \
     && rm -rf /tmp/$GLIBC_VER.apk /tmp/gcc /tmp/gcc-libs.tar.xz /var/cache/apk/*
 
 ENV JAVA_VERSION 1.9.0_ea2

--- a/ibmjava/9/sfj/x86_64/alpine/Dockerfile
+++ b/ibmjava/9/sfj/x86_64/alpine/Dockerfile
@@ -23,12 +23,12 @@ FROM alpine:3.6
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 
-RUN apk --update add --no-cache openssl ca-certificates xz \
+RUN apk --update add --no-cache ca-certificates curl openssl xz \
     && GLIBC_VER="2.25-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && wget -q -O /tmp/$GLIBC_VER.apk $ALPINE_GLIBC_REPO/$GLIBC_VER/glibc-$GLIBC_VER.apk \
+    && curl -Ls $ALPINE_GLIBC_REPO/$GLIBC_VER/glibc-$GLIBC_VER.apk > /tmp/$GLIBC_VER.apk \
     && apk add --allow-untrusted /tmp/$GLIBC_VER.apk \
-    && wget -q -O /tmp/gcc-libs.tar.xz https://www.archlinux.org/packages/core/x86_64/gcc-libs/download \
+    && curl -Ls https://www.archlinux.org/packages/core/x86_64/gcc-libs/download > /tmp/gcc-libs.tar.xz \
     && mkdir /tmp/gcc \
     && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \

--- a/ibmjava/9/sfj/x86_64/alpine/Dockerfile
+++ b/ibmjava/9/sfj/x86_64/alpine/Dockerfile
@@ -32,6 +32,7 @@ RUN apk --update add --no-cache ca-certificates curl openssl xz \
     && mkdir /tmp/gcc \
     && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
+    && apk del curl \
     && rm -rf /tmp/$GLIBC_VER.apk /tmp/gcc /tmp/gcc-libs.tar.xz /var/cache/apk/*
 
 ENV JAVA_VERSION 1.9.0_ea2

--- a/ibmjava/9/sfj/x86_64/alpine/Dockerfile
+++ b/ibmjava/9/sfj/x86_64/alpine/Dockerfile
@@ -19,16 +19,15 @@
 # limitations under the License.
 #
 
-FROM alpine:3.4
+FROM alpine:3.6
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 
-RUN apk --update add --no-cache openssl ca-certificates \
-    && GLIBC_VER="2.23-r3" \
+RUN apk --update add --no-cache openssl ca-certificates xz \
+    && GLIBC_VER="2.25-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
     && wget -q -O /tmp/$GLIBC_VER.apk $ALPINE_GLIBC_REPO/$GLIBC_VER/glibc-$GLIBC_VER.apk \
     && apk add --allow-untrusted /tmp/$GLIBC_VER.apk \
-    && apk --update add xz \
     && wget -q -O /tmp/gcc-libs.tar.xz https://www.archlinux.org/packages/core/x86_64/gcc-libs/download \
     && mkdir /tmp/gcc \
     && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \

--- a/ibmjava/README.md
+++ b/ibmjava/README.md
@@ -31,12 +31,12 @@ The Small Footprint JRE ([SFJ](http://www.ibm.com/support/knowledgecenter/en/SSY
 
 ##### Alpine Linux
 
-Consider using [Alpine Linux](http://alpinelinux.org/) if you are concerned about the size of the overall image. Alpine Linux is a stripped down version of Linux that is based on [musl libc](http://wiki.musl-libc.org/wiki/Functional_differences_from_glibc) and Busybox, resulting in a [Docker image](https://hub.docker.com/_/alpine/) size of approximately 5 MB. Due to its extremely small size and reduced number of installed packages, it has a much smaller attack surface which improves security. However, because the IBM SDK has a dependency on gnu glibc, installing this library adds an extra 8 MB to the image size. The following table compares Docker Image sizes based on JRE version `8.0-3.10`.
+Consider using [Alpine Linux](http://alpinelinux.org/) if you are concerned about the size of the overall image. Alpine Linux is a stripped down version of Linux that is based on [musl libc](http://wiki.musl-libc.org/wiki/Functional_differences_from_glibc) and Busybox, resulting in a [Docker image](https://hub.docker.com/_/alpine/) size of approximately 5 MB. Due to its extremely small size and reduced number of installed packages, it has a much smaller attack surface which improves security. However, because the IBM SDK has a dependency on gnu glibc, installing this library adds an extra 8 MB to the image size. The following table compares Docker Image sizes based on JRE version `8.0-4.6`.
 
 |   JRE  |   JRE  |   SFJ  |   SFJ  |
 |:------:|:------:|:------:|:------:|
 | Ubuntu | Alpine | Ubuntu | Alpine |
-| 305 MB | 184 MB | 220 MB | 101 MB |
+| 298 MB | 186 MB | 216 MB | 103 MB |
 
 **Note: Alpine Linux is not an officially supported operating system for IBM® SDK, Java™ Technology Edition.**
 

--- a/ibmjava/tests/input.txt
+++ b/ibmjava/tests/input.txt
@@ -2,11 +2,13 @@ ibmjava:8-sfj-alpine  ../8/sfj/x86_64/alpine
 ibmjava:8-sfj         ../8/sfj/x86_64/ubuntu
 ibmjava:8-jre-alpine  ../8/jre/x86_64/alpine
 ibmjava:8-jre         ../8/jre/x86_64/ubuntu
+ibmjava:8-sdk-alpine  ../8/sdk/x86_64/alpine
 ibmjava:8-sdk         ../8/sdk/x86_64/ubuntu
 ibmjava:9-sfj-alpine  ../9/sfj/x86_64/alpine
 ibmjava:9-sfj         ../9/sfj/x86_64/ubuntu
 ibmjava:9-jre-alpine  ../9/jre/x86_64/alpine
 ibmjava:9-jre         ../9/jre/x86_64/ubuntu
+ibmjava:9-sdk-alpine  ../9/sdk/x86_64/alpine
 ibmjava:9-sdk         ../9/sdk/x86_64/ubuntu
 i386/ibmjava:8-sfj    ../8/sfj/i386/ubuntu
 i386/ibmjava:8-jre    ../8/jre/i386/ubuntu

--- a/ibmjava/tests/version-info/8-sdk-alpine.txt
+++ b/ibmjava/tests/version-info/8-sdk-alpine.txt
@@ -1,0 +1,8 @@
+java version "1.8.0"
+Java(TM) SE Runtime Environment (build pxa6480sr4fp6-20170518_02(SR4 FP6))
+IBM J9 VM (build 2.8, JRE 1.8.0 Linux amd64-64 Compressed References 20170516_348050 (JIT enabled, AOT enabled)
+J9VM - R28_20170516_1905_B348050
+JIT  - tr.r14.java_20170516_348050
+GC   - R28_20170516_1905_B348050_CMPRSS
+J9CL - 20170516_348050)
+JCL - 20170516_01 based on Oracle jdk8u131-b11

--- a/ibmjava/tests/version-info/9-sdk-alpine.txt
+++ b/ibmjava/tests/version-info/9-sdk-alpine.txt
@@ -1,0 +1,7 @@
+java version "9-internal"
+Java(TM) SE Runtime Environment (build pxa6490ea-20170131_01)
+IBM J9 VM build 2.9, JRE 9 Linux amd64-64 Compressed References 20170119_333874 (JIT enabled, AOT enabled)
+J9VM - db9efe2
+JIT  - tr.open_20170112_130759_30d51616.green
+OMR   - 50f3d85
+JCL - 20170130_01 based on Oracle jdk-9+136

--- a/ibmjava/update.sh
+++ b/ibmjava/update.sh
@@ -155,12 +155,12 @@ EOI
 print_alpine_pkg() {
 	cat >> $1 <<'EOI'
 
-RUN apk --update add --no-cache openssl ca-certificates xz \
+RUN apk --update add --no-cache ca-certificates curl openssl xz \
     && GLIBC_VER="2.25-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && wget -q -O /tmp/$GLIBC_VER.apk $ALPINE_GLIBC_REPO/$GLIBC_VER/glibc-$GLIBC_VER.apk \
+    && curl -Ls $ALPINE_GLIBC_REPO/$GLIBC_VER/glibc-$GLIBC_VER.apk > /tmp/$GLIBC_VER.apk \
     && apk add --allow-untrusted /tmp/$GLIBC_VER.apk \
-    && wget -q -O /tmp/gcc-libs.tar.xz https://www.archlinux.org/packages/core/x86_64/gcc-libs/download \
+    && curl -Ls https://www.archlinux.org/packages/core/x86_64/gcc-libs/download > /tmp/gcc-libs.tar.xz \
     && mkdir /tmp/gcc \
     && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
 EOI

--- a/ibmjava/update.sh
+++ b/ibmjava/update.sh
@@ -115,7 +115,7 @@ print_ubuntu_os() {
 # Print the supported Alpine OS
 print_alpine_os() {
 	cat >> $1 <<-EOI
-	FROM alpine:3.4
+	FROM alpine:3.6
 
 	EOI
 }
@@ -155,12 +155,11 @@ EOI
 print_alpine_pkg() {
 	cat >> $1 <<'EOI'
 
-RUN apk --update add --no-cache openssl ca-certificates \
-    && GLIBC_VER="2.23-r3" \
+RUN apk --update add --no-cache openssl ca-certificates xz \
+    && GLIBC_VER="2.25-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
     && wget -q -O /tmp/$GLIBC_VER.apk $ALPINE_GLIBC_REPO/$GLIBC_VER/glibc-$GLIBC_VER.apk \
     && apk add --allow-untrusted /tmp/$GLIBC_VER.apk \
-    && apk --update add xz \
     && wget -q -O /tmp/gcc-libs.tar.xz https://www.archlinux.org/packages/core/x86_64/gcc-libs/download \
     && mkdir /tmp/gcc \
     && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
@@ -374,8 +373,8 @@ do
 				if [ "$os" == "ubuntu" ]; then
 					generate_ubuntu $file
 				elif [ "$os" == "alpine" ]; then
-					# Alpine is supported for x86_64 arch and JRE and SFJ packages only
-					if [ "$arch" == "x86_64" ] && [ "$pack" == "jre" -o "$pack" == "sfj" ]; then
+					# Alpine is supported for x86_64 arch only
+					if [ "$arch" == "x86_64" ]; then
 						generate_alpine $file
 					fi
 				fi

--- a/ibmjava/update.sh
+++ b/ibmjava/update.sh
@@ -173,6 +173,7 @@ EOI
 
 	cat >> $1 <<-EOI
     $GLIBC_PKGS
+    && apk del curl \\
     && rm -rf /tmp/\$GLIBC_VER.apk /tmp/gcc /tmp/gcc-libs.tar.xz /var/cache/apk/*
 EOI
 }


### PR DESCRIPTION
This update increases the size of the sfj-alpine docker image by 2.2 MB. This is because the Alpine Linux starting from 3.5 onwards includes ```/lib/libcrypto.so.41.0.1``` and ```/lib/libssl.so.43.0.2``` to support the ```apk``` tool.

```
REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
ibmjava             sfj-alpine          8386d318d15f        2 weeks ago         101.2 MB
j9                  8-sfj-alpine        99f0245ba768        3 minutes ago       103.4 MB
```