### PR TITLE
Remove OpenSSL from published Alpine images

### DIFF
--- a/ibmjava/8/jre/alpine/Dockerfile
+++ b/ibmjava/8/jre/alpine/Dockerfile
@@ -23,7 +23,7 @@ FROM alpine:3.7
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 
-RUN apk --update add --no-cache binutils ca-certificates openssl wget xz \
+RUN apk --update add --no-cache --virtual .build-deps binutils ca-certificates wget xz \
     && GLIBC_VER="2.25-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
     && wget -q -O /tmp/${GLIBC_VER}.apk ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-${GLIBC_VER}.apk \
@@ -33,7 +33,7 @@ RUN apk --update add --no-cache binutils ca-certificates openssl wget xz \
     && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
-    && apk del binutils wget \
+    && apk del .build-deps \
     && rm -rf /tmp/${GLIBC_VER}.apk /tmp/gcc /tmp/gcc-libs.tar.xz /var/cache/apk/*
 
 ENV JAVA_VERSION 1.8.0_sr5fp26

--- a/ibmjava/8/sdk/alpine/Dockerfile
+++ b/ibmjava/8/sdk/alpine/Dockerfile
@@ -23,7 +23,7 @@ FROM alpine:3.7
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 
-RUN apk --update add --no-cache binutils ca-certificates openssl wget xz \
+RUN apk --update add --no-cache --virtual .build-deps binutils ca-certificates wget xz \
     && GLIBC_VER="2.25-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
     && wget -q -O /tmp/${GLIBC_VER}.apk ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-${GLIBC_VER}.apk \
@@ -33,7 +33,7 @@ RUN apk --update add --no-cache binutils ca-certificates openssl wget xz \
     && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
-    && apk del binutils wget \
+    && apk del .build-deps \
     && rm -rf /tmp/${GLIBC_VER}.apk /tmp/gcc /tmp/gcc-libs.tar.xz /var/cache/apk/*
 
 ENV JAVA_VERSION 1.8.0_sr5fp26

--- a/ibmjava/8/sfj/alpine/Dockerfile
+++ b/ibmjava/8/sfj/alpine/Dockerfile
@@ -23,7 +23,7 @@ FROM alpine:3.7
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 
-RUN apk --update add --no-cache binutils ca-certificates openssl wget xz \
+RUN apk --update add --no-cache --virtual .build-deps binutils ca-certificates wget xz \
     && GLIBC_VER="2.25-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
     && wget -q -O /tmp/${GLIBC_VER}.apk ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-${GLIBC_VER}.apk \
@@ -33,7 +33,7 @@ RUN apk --update add --no-cache binutils ca-certificates openssl wget xz \
     && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
-    && apk del binutils wget \
+    && apk del .build-deps \
     && rm -rf /tmp/${GLIBC_VER}.apk /tmp/gcc /tmp/gcc-libs.tar.xz /var/cache/apk/*
 
 ENV JAVA_VERSION 1.8.0_sr5fp26

--- a/ibmjava/update.sh
+++ b/ibmjava/update.sh
@@ -135,7 +135,7 @@ EOI
 print_alpine_pkg() {
 	cat >> $1 <<'EOI'
 
-RUN apk --update add --no-cache binutils ca-certificates openssl wget xz \
+RUN apk --update add --no-cache --virtual .build-deps binutils ca-certificates wget xz \
     && GLIBC_VER="2.25-r0" \
     && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
     && wget -q -O /tmp/${GLIBC_VER}.apk ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-${GLIBC_VER}.apk \
@@ -145,7 +145,7 @@ RUN apk --update add --no-cache binutils ca-certificates openssl wget xz \
     && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
     && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
     && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
-    && apk del binutils wget \
+    && apk del .build-deps \
     && rm -rf /tmp/${GLIBC_VER}.apk /tmp/gcc /tmp/gcc-libs.tar.xz /var/cache/apk/*
 EOI
 }


### PR DESCRIPTION
Previously the Dockerfile's were all installing ca-certificates, curl
and openssl to allow them to securely fetch the glibc apk and the
jre/sdk. However, they were a) not removing openssl after making use of
it and b) including an outdated version (from alpine 3.6 repos
pre-April?) so any downstream images that built upon this official image
are flagged up for various CVEs in 1.0.2n but fixed in 1.0.2o(e.g.,
CVE-2017-3738, CVE-2018-0733, CVE-2018-0739)

```
$ docker run --rm -it ibmjava:8-sfj-alpine apk info -e openssl -d
openssl-1.0.2n-r0 description:
Toolkit for SSL v2/v3 and TLS v1
```

I don't believe there is a need to ship OpenSSL in the image itself, so
this PR switches to adding-and-removing the buildtime dependencies. It
also switches to using LibreSSL as that is what Alpine Linux uses by
default and most OpenSSL CVEs do not apply to it.