### PR TITLE
Add container support as a default option.

### DIFF
--- a/ibmjava/8/jre/alpine/Dockerfile
+++ b/ibmjava/8/jre/alpine/Dockerfile
@@ -82,4 +82,5 @@ RUN set -eux; \
     rm -f /tmp/ibm-java.bin;
 
 ENV JAVA_HOME=/opt/ibm/java/jre \
-    PATH=/opt/ibm/java/jre/bin:$PATH
+    PATH=/opt/ibm/java/jre/bin:$PATH \
+    IBM_JAVA_OPTIONS="-XX:+UseContainerSupport"

--- a/ibmjava/8/jre/ubuntu/Dockerfile
+++ b/ibmjava/8/jre/ubuntu/Dockerfile
@@ -73,4 +73,5 @@ RUN set -eux; \
     rm -f /tmp/ibm-java.bin;
 
 ENV JAVA_HOME=/opt/ibm/java/jre \
-    PATH=/opt/ibm/java/jre/bin:$PATH
+    PATH=/opt/ibm/java/jre/bin:$PATH \
+    IBM_JAVA_OPTIONS="-XX:+UseContainerSupport"

--- a/ibmjava/8/sdk/alpine/Dockerfile
+++ b/ibmjava/8/sdk/alpine/Dockerfile
@@ -82,4 +82,5 @@ RUN set -eux; \
     rm -f /tmp/ibm-java.bin;
 
 ENV JAVA_HOME=/opt/ibm/java/jre \
-    PATH=/opt/ibm/java/bin:$PATH
+    PATH=/opt/ibm/java/bin:$PATH \
+    IBM_JAVA_OPTIONS="-XX:+UseContainerSupport"

--- a/ibmjava/8/sdk/ubuntu/Dockerfile
+++ b/ibmjava/8/sdk/ubuntu/Dockerfile
@@ -73,4 +73,5 @@ RUN set -eux; \
     rm -f /tmp/ibm-java.bin;
 
 ENV JAVA_HOME=/opt/ibm/java/jre \
-    PATH=/opt/ibm/java/bin:$PATH
+    PATH=/opt/ibm/java/bin:$PATH \
+    IBM_JAVA_OPTIONS="-XX:+UseContainerSupport"

--- a/ibmjava/8/sfj/alpine/Dockerfile
+++ b/ibmjava/8/sfj/alpine/Dockerfile
@@ -82,4 +82,5 @@ RUN set -eux; \
     rm -f /tmp/ibm-java.bin;
 
 ENV JAVA_HOME=/opt/ibm/java/jre \
-    PATH=/opt/ibm/java/jre/bin:$PATH
+    PATH=/opt/ibm/java/jre/bin:$PATH \
+    IBM_JAVA_OPTIONS="-XX:+UseContainerSupport"

--- a/ibmjava/8/sfj/ubuntu/Dockerfile
+++ b/ibmjava/8/sfj/ubuntu/Dockerfile
@@ -73,4 +73,5 @@ RUN set -eux; \
     rm -f /tmp/ibm-java.bin;
 
 ENV JAVA_HOME=/opt/ibm/java/jre \
-    PATH=/opt/ibm/java/jre/bin:$PATH
+    PATH=/opt/ibm/java/jre/bin:$PATH \
+    IBM_JAVA_OPTIONS="-XX:+UseContainerSupport"

--- a/ibmjava/update.sh
+++ b/ibmjava/update.sh
@@ -276,7 +276,8 @@ print_java_env() {
 	cat >> $1 <<-EOI
 
 ENV JAVA_HOME=${JHOME} \\
-    ${TPATH}
+    ${TPATH} \\
+    IBM_JAVA_OPTIONS="-XX:+UseContainerSupport"
 EOI
 }
 


### PR DESCRIPTION
IBM Java Java 8 SR5 FP16  now has Docker support. However FP16 will not have Docker support turned on by default and we need to the -XX:+UseContainerSupport flag to do so. This will do the following

1. Recognize that the JVM is running in a container
2. Limit the default max heap size to 75% of the container mem limit if any (Provided no -Xmx is set)