### PR TITLE
Bump up Alpine to use 3.7

### DIFF
--- a/ibmjava/8/jre/alpine/Dockerfile
+++ b/ibmjava/8/jre/alpine/Dockerfile
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.6
+FROM alpine:3.7
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 

--- a/ibmjava/8/sdk/alpine/Dockerfile
+++ b/ibmjava/8/sdk/alpine/Dockerfile
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.6
+FROM alpine:3.7
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 

--- a/ibmjava/8/sfj/alpine/Dockerfile
+++ b/ibmjava/8/sfj/alpine/Dockerfile
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.6
+FROM alpine:3.7
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 

--- a/ibmjava/tests/build.sh
+++ b/ibmjava/tests/build.sh
@@ -44,7 +44,7 @@ echo "**************************************************************************
 echo "           Starting docker build for $image                                   "
 echo "******************************************************************************"
 
-docker build --no-cache --pull -t $image $dloc  > build_$tag.log
+docker build --no-cache --pull -t $image $dloc 2>&1 | tee build_$tag.log
 
 if [ $? = 0 ]
 then

--- a/ibmjava/update.sh
+++ b/ibmjava/update.sh
@@ -100,7 +100,7 @@ print_ubuntu_os() {
 # Print the supported Alpine OS
 print_alpine_os() {
 	cat >> $1 <<-EOI
-	FROM alpine:3.6
+	FROM alpine:3.7
 
 	EOI
 }


### PR DESCRIPTION
3.7 has been tested for a while now at [AdoptOpenJDK](https://github.com/AdoptOpenJDK/openjdk-docker).