### PR TITLE
ubi-minimal image

### DIFF
--- a/ibmjava/8/jre/ubi-min/Dockerfile
+++ b/ibmjava/8/jre/ubi-min/Dockerfile
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-FROM registry.access.redhat.com/ubi7-dev-preview/ubi-minimal
+FROM registry.access.redhat.com/ubi7/ubi-minimal
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 

--- a/ibmjava/8/jre/ubi-min/Dockerfile
+++ b/ibmjava/8/jre/ubi-min/Dockerfile
@@ -1,0 +1,77 @@
+# (C) Copyright IBM Corporation 2016, 2018
+#
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM registry.access.redhat.com/ubi7-dev-preview/ubi-minimal
+
+MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
+
+RUN microdnf install openssl wget ca-certificates gzip tar && \
+    microdnf update; microdnf clean all
+
+
+ENV JAVA_VERSION 1.8.0_sr5fp31
+
+RUN set -eux; \
+    ARCH="$(arch)"; \
+    case "${ARCH}" in \
+       amd64|x86_64) \
+         ESUM='950c6a4d40d9d73a65f9f995f07add4d95315937fae9c11ec97a75369dc6a834'; \
+         YML_FILE='jre/linux/x86_64/index.yml'; \
+         ;; \
+       i386) \
+         ESUM='b31a5404181008a761631991827539f9c7c8140702393051c62300c648cc1af6'; \
+         YML_FILE='jre/linux/i386/index.yml'; \
+         ;; \
+       ppc64el|ppc64le) \
+         ESUM='1b669fe7429619c0b1dc278168e23fad9785881a64a8041f091e56a9c361bc54'; \
+         YML_FILE='jre/linux/ppc64le/index.yml'; \
+         ;; \
+       s390) \
+         ESUM='3552696fb870f7777cf5ab3317e756eef3720729483b6dc9c8ccf3e7482ab6cb'; \
+         YML_FILE='jre/linux/s390/index.yml'; \
+         ;; \
+       s390x) \
+         ESUM='b10ec022a1af888a778d2cfb446c3f1b8c8d949f4c79c9072f530a65533b6cda'; \
+         YML_FILE='jre/linux/s390x/index.yml'; \
+         ;; \
+       *) \
+         echo "Unsupported arch: ${ARCH}"; \
+         exit 1; \
+         ;; \
+    esac; \
+    BASE_URL="https://public.dhe.ibm.com/ibmdl/export/pub/systems/cloud/runtimes/java/meta/"; \
+    wget -q -U UA_IBM_JAVA_Docker -O /tmp/index.yml ${BASE_URL}/${YML_FILE}; \
+    JAVA_URL=$(sed -n '/^'${JAVA_VERSION}:'/{n;s/\s*uri:\s//p}'< /tmp/index.yml); \
+    wget -q -U UA_IBM_JAVA_Docker -O /tmp/ibm-java.bin ${JAVA_URL}; \
+    echo "${ESUM}  /tmp/ibm-java.bin" | sha256sum -c -; \
+    echo "INSTALLER_UI=silent" > /tmp/response.properties; \
+    echo "USER_INSTALL_DIR=/opt/ibm/java" >> /tmp/response.properties; \
+    echo "LICENSE_ACCEPTED=TRUE" >> /tmp/response.properties; \
+    mkdir -p /opt/ibm; \
+    chmod +x /tmp/ibm-java.bin; \
+    /tmp/ibm-java.bin -i silent -f /tmp/response.properties; \
+    rm -f /tmp/response.properties; \
+    rm -f /tmp/index.yml; \
+    rm -f /tmp/ibm-java.bin;
+
+ENV JAVA_HOME=/opt/ibm/java/jre \
+    PATH=/opt/ibm/java/jre/bin:$PATH \
+    IBM_JAVA_OPTIONS="-XX:+UseContainerSupport"

--- a/ibmjava/8/sdk/ubi-min/Dockerfile
+++ b/ibmjava/8/sdk/ubi-min/Dockerfile
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-FROM registry.access.redhat.com/ubi7-dev-preview/ubi-minimal
+FROM registry.access.redhat.com/ubi7/ubi-minimal
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 

--- a/ibmjava/8/sdk/ubi-min/Dockerfile
+++ b/ibmjava/8/sdk/ubi-min/Dockerfile
@@ -1,0 +1,77 @@
+# (C) Copyright IBM Corporation 2016, 2018
+#
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM registry.access.redhat.com/ubi7-dev-preview/ubi-minimal
+
+MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
+
+RUN microdnf install openssl wget ca-certificates gzip tar && \
+    microdnf update; microdnf clean all
+
+
+ENV JAVA_VERSION 1.8.0_sr5fp31
+
+RUN set -eux; \
+    ARCH="$(arch)"; \
+    case "${ARCH}" in \
+       amd64|x86_64) \
+         ESUM='81dd952a9e00ebbaf91fe33544b7b023bf9446e352c9e22e63ec41a3c375e0ba'; \
+         YML_FILE='sdk/linux/x86_64/index.yml'; \
+         ;; \
+       i386) \
+         ESUM='ce25f618aa536af52972a40ee91975d11385aa92b8cf8fc26cedd43b48276e6d'; \
+         YML_FILE='sdk/linux/i386/index.yml'; \
+         ;; \
+       ppc64el|ppc64le) \
+         ESUM='cb7c40da9c0f78f3a200a426e54c6c2889d9726854cdc6c540562589e815c581'; \
+         YML_FILE='sdk/linux/ppc64le/index.yml'; \
+         ;; \
+       s390) \
+         ESUM='21b526cd5bf2b5570e83bdc9f03e93ea1fce5b42358001bea1fd8a05c97b032c'; \
+         YML_FILE='sdk/linux/s390/index.yml'; \
+         ;; \
+       s390x) \
+         ESUM='22445ef768af621d817dcc3a76e772588b827e28256f7db7d5574f146b13e31a'; \
+         YML_FILE='sdk/linux/s390x/index.yml'; \
+         ;; \
+       *) \
+         echo "Unsupported arch: ${ARCH}"; \
+         exit 1; \
+         ;; \
+    esac; \
+    BASE_URL="https://public.dhe.ibm.com/ibmdl/export/pub/systems/cloud/runtimes/java/meta/"; \
+    wget -q -U UA_IBM_JAVA_Docker -O /tmp/index.yml ${BASE_URL}/${YML_FILE}; \
+    JAVA_URL=$(sed -n '/^'${JAVA_VERSION}:'/{n;s/\s*uri:\s//p}'< /tmp/index.yml); \
+    wget -q -U UA_IBM_JAVA_Docker -O /tmp/ibm-java.bin ${JAVA_URL}; \
+    echo "${ESUM}  /tmp/ibm-java.bin" | sha256sum -c -; \
+    echo "INSTALLER_UI=silent" > /tmp/response.properties; \
+    echo "USER_INSTALL_DIR=/opt/ibm/java" >> /tmp/response.properties; \
+    echo "LICENSE_ACCEPTED=TRUE" >> /tmp/response.properties; \
+    mkdir -p /opt/ibm; \
+    chmod +x /tmp/ibm-java.bin; \
+    /tmp/ibm-java.bin -i silent -f /tmp/response.properties; \
+    rm -f /tmp/response.properties; \
+    rm -f /tmp/index.yml; \
+    rm -f /tmp/ibm-java.bin;
+
+ENV JAVA_HOME=/opt/ibm/java/jre \
+    PATH=/opt/ibm/java/bin:$PATH \
+    IBM_JAVA_OPTIONS="-XX:+UseContainerSupport"

--- a/ibmjava/8/sfj/ubi-min/Dockerfile
+++ b/ibmjava/8/sfj/ubi-min/Dockerfile
@@ -1,0 +1,77 @@
+# (C) Copyright IBM Corporation 2016, 2018
+#
+# ------------------------------------------------------------------------------
+#               NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+#                       PLEASE DO NOT EDIT IT DIRECTLY.
+# ------------------------------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM registry.access.redhat.com/ubi7-dev-preview/ubi-minimal
+
+MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
+
+RUN microdnf install openssl wget ca-certificates gzip tar && \
+    microdnf update; microdnf clean all
+
+
+ENV JAVA_VERSION 1.8.0_sr5fp31
+
+RUN set -eux; \
+    ARCH="$(arch)"; \
+    case "${ARCH}" in \
+       amd64|x86_64) \
+         ESUM='3eb7ddd1ad561dac947c9c0b6a934f754135f117226d057b4b9089bf1e6f9294'; \
+         YML_FILE='sfj/linux/x86_64/index.yml'; \
+         ;; \
+       i386) \
+         ESUM='451198482dec4be1c937b4964cb79ce41371636b9b8cf6341f0199784d090703'; \
+         YML_FILE='sfj/linux/i386/index.yml'; \
+         ;; \
+       ppc64el|ppc64le) \
+         ESUM='2391946144755b9d80ec3b516e87a26047f296076410f452bc0c4cdf17a68e47'; \
+         YML_FILE='sfj/linux/ppc64le/index.yml'; \
+         ;; \
+       s390) \
+         ESUM='9abbd8edf703c28c064362d6c953db658baefb9ec73562d9a0d554b71c5b4882'; \
+         YML_FILE='sfj/linux/s390/index.yml'; \
+         ;; \
+       s390x) \
+         ESUM='9db32da5204c5e53bd7a1344af9a919dd46cf82f40707e86e9c65ff902b40d01'; \
+         YML_FILE='sfj/linux/s390x/index.yml'; \
+         ;; \
+       *) \
+         echo "Unsupported arch: ${ARCH}"; \
+         exit 1; \
+         ;; \
+    esac; \
+    BASE_URL="https://public.dhe.ibm.com/ibmdl/export/pub/systems/cloud/runtimes/java/meta/"; \
+    wget -q -U UA_IBM_JAVA_Docker -O /tmp/index.yml ${BASE_URL}/${YML_FILE}; \
+    JAVA_URL=$(sed -n '/^'${JAVA_VERSION}:'/{n;s/\s*uri:\s//p}'< /tmp/index.yml); \
+    wget -q -U UA_IBM_JAVA_Docker -O /tmp/ibm-java.bin ${JAVA_URL}; \
+    echo "${ESUM}  /tmp/ibm-java.bin" | sha256sum -c -; \
+    echo "INSTALLER_UI=silent" > /tmp/response.properties; \
+    echo "USER_INSTALL_DIR=/opt/ibm/java" >> /tmp/response.properties; \
+    echo "LICENSE_ACCEPTED=TRUE" >> /tmp/response.properties; \
+    mkdir -p /opt/ibm; \
+    chmod +x /tmp/ibm-java.bin; \
+    /tmp/ibm-java.bin -i silent -f /tmp/response.properties; \
+    rm -f /tmp/response.properties; \
+    rm -f /tmp/index.yml; \
+    rm -f /tmp/ibm-java.bin;
+
+ENV JAVA_HOME=/opt/ibm/java/jre \
+    PATH=/opt/ibm/java/jre/bin:$PATH \
+    IBM_JAVA_OPTIONS="-XX:+UseContainerSupport"

--- a/ibmjava/8/sfj/ubi-min/Dockerfile
+++ b/ibmjava/8/sfj/ubi-min/Dockerfile
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-FROM registry.access.redhat.com/ubi7-dev-preview/ubi-minimal
+FROM registry.access.redhat.com/ubi7/ubi-minimal
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 

--- a/ibmjava/update.sh
+++ b/ibmjava/update.sh
@@ -116,7 +116,7 @@ print_rhel_os() {
 # Print the supported UBI Minimal OS
 print_ubi-min_os() {
 	cat >> $1 <<-EOI
-	FROM registry.access.redhat.com/ubi7-dev-preview/ubi-minimal
+	FROM registry.access.redhat.com/ubi7/ubi-minimal
 
 	EOI
 }


### PR DESCRIPTION
@qerub
@samuel-hawker
@arthurdm 

Continued from
https://github.com/ibmruntimes/ci.docker/pull/53

Preserves the standard rhel image
Produces a ubi-min image of jre, sdk, sfj