### PR TITLE
Update Alpine version

### DIFF
--- a/ibmjava/8/jre/alpine/Dockerfile
+++ b/ibmjava/8/jre/alpine/Dockerfile
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.7
+FROM alpine:3.10
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 

--- a/ibmjava/8/sdk/alpine/Dockerfile
+++ b/ibmjava/8/sdk/alpine/Dockerfile
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.7
+FROM alpine:3.10
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 

--- a/ibmjava/8/sfj/alpine/Dockerfile
+++ b/ibmjava/8/sfj/alpine/Dockerfile
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-FROM alpine:3.7
+FROM alpine:3.10
 
 MAINTAINER Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 

--- a/ibmjava/update.sh
+++ b/ibmjava/update.sh
@@ -100,7 +100,7 @@ print_ubuntu_os() {
 # Print the supported Alpine OS
 print_alpine_os() {
 	cat >> $1 <<-EOI
-	FROM alpine:3.7
+	FROM alpine:3.10
 
 	EOI
 }


### PR DESCRIPTION
Following https://wiki.alpinelinux.org/wiki/Alpine_Linux:Releases:
Alpine 3.7 is out of support on 1st November 2019

Would properly close #112