### PR TITLE
Updating UBI images

### DIFF
--- a/ibmjava/8/jre/ubi-min/Dockerfile
+++ b/ibmjava/8/jre/ubi-min/Dockerfile
@@ -38,7 +38,6 @@ ENV JAVA_VERSION 1.8.0_sr5fp41
 
 RUN set -eux; \
     microdnf -y install shadow-utils; \
-    useradd -u 1001 -r -g 0 -s /usr/sbin/nologin default; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        amd64|x86_64) \
@@ -73,7 +72,6 @@ RUN set -eux; \
     rm -f /tmp/index.yml; \
     mkdir -p /licenses; \
     cp /opt/ibm/java/license_en.txt /licenses; \
-    chown -R 1001:0 /opt/ibm/java; \
     microdnf -y remove shadow-utils; \
     microdnf clean all; \
     rm -f /tmp/ibm-java.bin;
@@ -81,5 +79,3 @@ RUN set -eux; \
 ENV JAVA_HOME=/opt/ibm/java/jre \
     PATH=/opt/ibm/java/jre/bin:$PATH \
     IBM_JAVA_OPTIONS="-XX:+UseContainerSupport"
-
-USER 1001

--- a/ibmjava/8/jre/ubi-min/Dockerfile
+++ b/ibmjava/8/jre/ubi-min/Dockerfile
@@ -38,6 +38,7 @@ ENV JAVA_VERSION 1.8.0_sr5fp41
 
 RUN set -eux; \
     microdnf -y install shadow-utils; \
+    useradd -u 1001 -r -g 0 -s /usr/sbin/nologin default; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        amd64|x86_64) \
@@ -72,6 +73,7 @@ RUN set -eux; \
     rm -f /tmp/index.yml; \
     mkdir -p /licenses; \
     cp /opt/ibm/java/license_en.txt /licenses; \
+    chown -R 1001:0 /opt/ibm/java; \
     microdnf -y remove shadow-utils; \
     microdnf clean all; \
     rm -f /tmp/ibm-java.bin;
@@ -79,3 +81,5 @@ RUN set -eux; \
 ENV JAVA_HOME=/opt/ibm/java/jre \
     PATH=/opt/ibm/java/jre/bin:$PATH \
     IBM_JAVA_OPTIONS="-XX:+UseContainerSupport"
+
+USER 1001

--- a/ibmjava/8/jre/ubi/Dockerfile
+++ b/ibmjava/8/jre/ubi/Dockerfile
@@ -37,7 +37,6 @@ LABEL org.opencontainers.image.authors="Jayashree Gopi <jayasg12@in.ibm.com>" \
 ENV JAVA_VERSION 1.8.0_sr5fp41
 
 RUN set -eux; \
-    useradd -u 1001 -r -g 0 -s /usr/sbin/nologin default; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        amd64|x86_64) \
@@ -72,11 +71,8 @@ RUN set -eux; \
     rm -f /tmp/index.yml; \
     mkdir -p /licenses; \
     cp /opt/ibm/java/license_en.txt /licenses; \
-    chown -R 1001:0 /opt/ibm/java; \
     rm -f /tmp/ibm-java.bin;
 
 ENV JAVA_HOME=/opt/ibm/java/jre \
     PATH=/opt/ibm/java/jre/bin:$PATH \
     IBM_JAVA_OPTIONS="-XX:+UseContainerSupport"
-
-USER 1001


### PR DESCRIPTION
In order to be consistent with AdoptOpenJDK's UBI images, as well as the other published IBM Java images, I propose that we do not create user `1001` in the UBI Java layer.

This creates an issue in downstream images, such as Liberty, because we need to switch to `root` to do things like `yum install xyz` (creating a larger image size), and requires us to keep different Dockerfiles from our AdoptOpenJDK-based ones (where we need to create user 1001 ourselves).