### PR TITLE
Update UBI to ubi 8.2

### DIFF
--- a/ibmjava/8/jre/ubi/Dockerfile
+++ b/ibmjava/8/jre/ubi/Dockerfile
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-FROM registry.access.redhat.com/ubi8/ubi
+FROM registry.access.redhat.com/ubi8/ubi:8.2
 
 
 RUN yum install -y wget openssl ca-certificates gzip tar \


### PR DESCRIPTION
The 8.2 tag has had recent security fixes (https://catalog.redhat.com/software/containers/detail/5c359854d70cc534b3a3784e?tag=8.2&container-tabs=overview).   The general `8` tag is a few months old now.