### PR TITLE
Modified verify.sh testJavaVersion function

### DIFF
--- a/ibmjava/tests/verify.sh
+++ b/ibmjava/tests/verify.sh
@@ -29,13 +29,13 @@ arch=`echo $image | cut -d "/" -f1`
 if [ "$arch" == "i386" ]; then
 	tag=$arch-`echo $image | cut -d ":" -f2`
 else
-	tag=`echo $image | cut -d ":" -f2`
+	tag=`echo $image | cut -d ":" -f2 | cut -d "-" -f1,2`
 fi
 
 testJavaVersion()
 {
-   docker run --rm $image java -version 2>testvers.log
-   comparison=$(diff -u testvers.log "$PWD/version-info/$tag.txt")
+   podman run --rm $image java -version 2>testvers.log
+   comparison=$(diff -u testvers.log $PWD/version-info/*$tag.txt)
 
    if [ $? != 0 ]
    then


### PR DESCRIPTION
Updated verify.sh to pick appropriate tag during java version file creation. Also updated docker run to podman run to avoid line "-Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg." in any of the server.


