### PR TITLE
Add label maintainer to ubi docker files

### DIFF
--- a/ibmjava/8/jre/ubi-min/Dockerfile
+++ b/ibmjava/8/jre/ubi-min/Dockerfile
@@ -25,7 +25,8 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 RUN microdnf install openssl wget ca-certificates gzip tar \
     && microdnf update; microdnf clean all
 
-LABEL org.opencontainers.image.authors="Jayashree Gopi <jayasg12@in.ibm.com>" \
+LABEL org.opencontainers.image.authors="Jayashree Gopi" \
+    maintainer="jayasg12@in.ibm.com" \
     name="IBM JAVA" \
     vendor="IBM" \
     version=8.0.8.35 \

--- a/ibmjava/8/jre/ubi/Dockerfile
+++ b/ibmjava/8/jre/ubi/Dockerfile
@@ -25,7 +25,8 @@ FROM registry.access.redhat.com/ubi8/ubi:latest
 RUN yum install -y wget openssl ca-certificates gzip tar \
     && yum update; yum clean all
 
-LABEL org.opencontainers.image.authors="Jayashree Gopi <jayasg12@in.ibm.com>" \
+LABEL org.opencontainers.image.authors="Jayashree Gopi" \
+    maintainer="jayasg12@in.ibm.com" \
     name="IBM JAVA" \
     vendor="IBM" \
     version=8.0.8.35 \

--- a/ibmjava/8/sdk/ubi-min/Dockerfile
+++ b/ibmjava/8/sdk/ubi-min/Dockerfile
@@ -25,7 +25,8 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 RUN microdnf install openssl wget ca-certificates gzip tar \
     && microdnf update; microdnf clean all
 
-LABEL org.opencontainers.image.authors="Jayashree Gopi <jayasg12@in.ibm.com>" \
+LABEL org.opencontainers.image.authors="Jayashree Gopi" \
+    maintainer="jayasg12@in.ibm.com" \
     name="IBM JAVA" \
     vendor="IBM" \
     version=8.0.8.35 \

--- a/ibmjava/8/sdk/ubi/Dockerfile
+++ b/ibmjava/8/sdk/ubi/Dockerfile
@@ -25,7 +25,8 @@ FROM registry.access.redhat.com/ubi8/ubi:latest
 RUN yum install -y wget openssl ca-certificates gzip tar \
     && yum update; yum clean all
 
-LABEL org.opencontainers.image.authors="Jayashree Gopi <jayasg12@in.ibm.com>" \
+LABEL org.opencontainers.image.authors="Jayashree Gopi" \
+    maintainer="jayasg12@in.ibm.com" \
     name="IBM JAVA" \
     vendor="IBM" \
     version=8.0.8.35 \

--- a/ibmjava/8/sfj/ubi-min/Dockerfile
+++ b/ibmjava/8/sfj/ubi-min/Dockerfile
@@ -25,7 +25,8 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 RUN microdnf install openssl wget ca-certificates gzip tar \
     && microdnf update; microdnf clean all
 
-LABEL org.opencontainers.image.authors="Jayashree Gopi <jayasg12@in.ibm.com>" \
+LABEL org.opencontainers.image.authors="Jayashree Gopi" \
+    maintainer="jayasg12@in.ibm.com" \
     name="IBM JAVA" \
     vendor="IBM" \
     version=8.0.8.35 \

--- a/ibmjava/8/sfj/ubi/Dockerfile
+++ b/ibmjava/8/sfj/ubi/Dockerfile
@@ -25,7 +25,8 @@ FROM registry.access.redhat.com/ubi8/ubi:latest
 RUN yum install -y wget openssl ca-certificates gzip tar \
     && yum update; yum clean all
 
-LABEL org.opencontainers.image.authors="Jayashree Gopi <jayasg12@in.ibm.com>" \
+LABEL org.opencontainers.image.authors="Jayashree Gopi" \
+    maintainer="jayasg12@in.ibm.com" \
     name="IBM JAVA" \
     vendor="IBM" \
     version=8.0.8.35 \


### PR DESCRIPTION
Redhat making mandate to have maintainer info in the container file to publish the UBI images onto Redhat Repo.